### PR TITLE
Add XAIBase package extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Manifest.toml
 /test/Manifest.toml
 /docs/Manifest.toml
 /docs/build/
+settings.json

--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,27 @@
 name = "VisionHeatmaps"
 uuid = "27106da1-f8bc-4ca8-8c66-9b8289f1e035"
 authors = ["Adrian Hill <gh@adrianhill.de>"]
-version = "1.2.0"
+version = "1.3.0-DEV"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+XAIBase = "9b48221d-a747-4c1b-9860-46a1d8ba24a7"
+
+[weakdeps]
+XAIBase = "9b48221d-a747-4c1b-9860-46a1d8ba24a7"
+
+[extensions]
+VisionHeatmapsXAIBaseExt = "XAIBase"
 
 [compat]
 ColorSchemes = "3"
 ImageCore = "0.9, 0.10"
 ImageTransformations = "0.10"
 Interpolations = "0.15"
+Requires = "1"
+XAIBase = "3"
 julia = "1.6"

--- a/ext/VisionHeatmapsXAIBaseExt.jl
+++ b/ext/VisionHeatmapsXAIBaseExt.jl
@@ -1,0 +1,73 @@
+module VisionHeatmapsXAIBaseExt
+
+using VisionHeatmaps, XAIBase
+
+struct HeatmapConfig
+    colorscheme::Symbol
+    reduce::Symbol
+    rangescale::Symbol
+end
+
+const DEFAULT_COLORSCHEME = :seismic
+const DEFAULT_REDUCE = :sum
+const DEFAULT_RANGESCALE = :centered
+const DEFAULT_HEATMAP_PRESET = HeatmapConfig(
+    DEFAULT_COLORSCHEME, DEFAULT_REDUCE, DEFAULT_RANGESCALE
+)
+
+const HEATMAP_PRESETS = Dict{Symbol,HeatmapConfig}(
+    :attribution => HeatmapConfig(:seismic, :sum, :centered),
+    :sensitivity => HeatmapConfig(:grays, :norm, :extrema),
+    :cam         => HeatmapConfig(:jet, :sum, :extrema),
+)
+
+# Select HeatmapConfig preset based on heatmapping style in Explanation
+function get_heatmapping_config(heatmap::Symbol)
+    return get(HEATMAP_PRESETS, heatmap, DEFAULT_HEATMAP_PRESET)
+end
+
+# Override HeatmapConfig preset with keyword arguments
+function get_heatmapping_config(expl::Explanation; kwargs...)
+    c = get_heatmapping_config(expl.heatmap)
+
+    colorscheme = get(kwargs, :colorscheme, c.colorscheme)
+    rangescale  = get(kwargs, :rangescale, c.rangescale)
+    reduce      = get(kwargs, :reduce, c.reduce)
+    return HeatmapConfig(colorscheme, reduce, rangescale)
+end
+
+"""
+    heatmap(explanation)
+
+Visualize `Explanation` from XAIBase as a vision heatmap.
+Assumes WHCN convention (width, height, channels, batchsize) for `explanation.val`.
+"""
+function VisionHeatmaps.heatmap(expl::Explanation; kwargs...)
+    c = get_heatmapping_config(expl; kwargs...)
+    return heatmap(
+        expl.val;
+        colorscheme=c.colorscheme,
+        reduce=c.reduce,
+        rangescale=c.rangescale,
+        kwargs...,
+    )
+end
+
+"""
+    heatmap(input, analyzer)
+
+Compute an `Explanation` for a given `input` using the XAI method `analyzer` and visualize it
+as a vision heatmap.
+
+Any additional arguments and keyword arguments are passed to the analyzer.
+Refer to the `analyze` documentation for more information on available keyword arguments.
+
+To customize the heatmapping style, first compute an explanation using `analyze`
+and then call [`heatmap`](@ref) on the explanation.
+"""
+function VisionHeatmaps.heatmap(input, analyzer::AbstractXAIMethod, args...; kwargs...)
+    expl = analyze(input, analyzer, args...; kwargs...)
+    return heatmap(expl)
+end
+
+end # module

--- a/src/VisionHeatmaps.jl
+++ b/src/VisionHeatmaps.jl
@@ -4,9 +4,19 @@ using ColorSchemes: ColorScheme, colorschemes, get, seismic
 using ImageTransformations: imresize
 using Interpolations: Lanczos
 using ImageCore
+using Requires: @require
 
 include("heatmap.jl")
 include("overlay.jl")
+
+if !isdefined(Base, :get_extension)
+    using Requires
+    function __init__()
+        @require XAIBase = "9b48221d-a747-4c1b-9860-46a1d8ba24a7" include(
+            "../ext/VisionHeatmapsXAIBaseExt.jl"
+        )
+    end
+end
 
 export heatmap, heatmap_overlay
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,3 +5,7 @@ ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+XAIBase = "9b48221d-a747-4c1b-9860-46a1d8ba24a7"
+
+[compat]
+XAIBase = "3"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,4 +19,8 @@ using JuliaFormatter
         @info "Testing heatmaps..."
         include("test_heatmap.jl")
     end
+    @testset "XAIBase extension" begin
+        @info "Testing heatmaps on XAIBase explanations..."
+        include("test_xaibase_ext.jl")
+    end
 end

--- a/test/test_xaibase_ext.jl
+++ b/test/test_xaibase_ext.jl
@@ -1,0 +1,34 @@
+using XAIBase
+
+# NOTE: Heatmapping assumes Flux's WHCN convention (width, height, color channels, batch size).
+# Single input
+@testset "Single input" begin
+    shape = (2, 2, 3, 1)
+    val = output = reshape(collect(Float32, 1:prod(shape)), shape)
+    output_selection = [CartesianIndex(1, 2)] # irrelevant
+    expl = Explanation(val, output, [output_selection], :LRP, :attribution)
+
+    reducers = [:sum, :maxabs, :norm, :sumabs, :abssum]
+    rangescales = [:extrema, :centered]
+    for reducer in reducers
+        for rangescale in rangescales
+            local h = heatmap(expl; reduce=reducer, rangescale=rangescale)
+            @test_reference "references/$(reducer)_$(rangescale).txt" h
+            h2 = heatmap(
+                expl; reduce=reducer, rangescale=rangescale, unpack_singleton=false
+            )[1]
+            @test h ≈ h2
+        end
+    end
+end
+
+@testset "Batched input" begin
+    val = output = reshape(1:(2^4), 2, 2, 2, 2)
+    output_selection = [CartesianIndex(1, 2), CartesianIndex(3, 4)] # irrelevant
+    expl_batch = Explanation(val, output, output_selection, :LRP, :attribution)
+
+    h1 = heatmap(expl_batch)
+    h2 = heatmap(expl_batch; process_batch=true)
+    @test_reference "references/process_batch_false.txt" h1
+    @test_reference "references/process_batch_true.txt" h2
+end


### PR DESCRIPTION
Continues work started in https://github.com/Julia-XAI/XAIBase.jl/pull/16 by moving `heatmap` methods on `Explanation` type to VisionHeatmaps.jl via package extensions on XAIBase.